### PR TITLE
Update .gitignore to exclude .pyc and .pyo files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.egg-info
+*.py[co]


### PR DESCRIPTION
Not all contributors have this in their global .gitignore settings. Adding this to avoid any stray unstaged commits they may have when contributing to Mozilla projects that uses happyforms.
